### PR TITLE
Fix man page install location

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ fi
 # Ensure destination directories exist
 mkdir -p "${DESTDIR}/bin"
 mkdir -p "${DESTDIR}/lib"
-mkdir -p "${DESTDIR}/man/man1"
+mkdir -p "${DESTDIR}/share/man/man1"
 mkdir -p "${DESTDIR}/share/bash-completion/completions"
 
 $install_cmd "${FROM}/xmq" "${DESTDIR}/bin/xmq"
@@ -46,7 +46,7 @@ $install_shared_lib_cmd "${FROM}/libxmq.so" "${DESTDIR}/lib/libxmq.so"
 mkdir -p "${DESTDIR}/include"
 cp "src/main/c/xmq.h" "${DESTDIR}/include/xmq.h"
 chmod 644 "${DESTDIR}/include/xmq.h"
-install -m 644 "doc/xmq.1" "${DESTDIR}/man/man1/xmq.1"
+install -m 644 "doc/xmq.1" "${DESTDIR}/share/man/man1/xmq.1"
 install -m 644 "scripts/autocompletion_for_xmq.sh" "${DESTDIR}/share/bash-completion/completions/xmq"
 
 echo


### PR DESCRIPTION
I missed that when updating `install.sh`. The man page should now be picked up by the `man` command.